### PR TITLE
Replaces update indicator to be a unicode char

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -41,12 +41,5 @@ export function activate(context) {
     )
   );
 
-  // disposables.push(
-  //   commands.registerCommand(
-  //     `_${config.extentionName}.updateDependenciesCommand`,
-  //     updateDependenciesCommand
-  //   )
-  // );
-
   context.subscriptions.push(...disposables);
 }

--- a/src/models/appConfiguration.js
+++ b/src/models/appConfiguration.js
@@ -15,4 +15,8 @@ export class AppConfiguration {
     return config.get("versionPrefix", "");
   }
 
+  get updateIndicator() {
+    return '⬆';
+  }
+
 }

--- a/src/providers/abstractCodeLensProvider.js
+++ b/src/providers/abstractCodeLensProvider.js
@@ -85,7 +85,7 @@ export abstract class AbstractCodeLensProvider {
     }
 
     codeLensItem.command = {
-      title: `&uarr; ${this.appConfig.versionPrefix}${newerVersion}`,
+      title: `${this.appConfig.updateIndicator} ${this.appConfig.versionPrefix}${newerVersion}`,
       command: `_${this.appConfig.extentionName}.updateDependencyCommand`,
       arguments: [
         codeLensItem,
@@ -112,7 +112,7 @@ export abstract class AbstractCodeLensProvider {
     }
 
     codeLensItem.command = {
-      title: `&uarr; satisfies v${serverVersion}`,
+      title: `${this.appConfig.updateIndicator} satisfies v${serverVersion}`,
       command: `_${this.appConfig.extentionName}.updateDependencyCommand`,
       arguments: [
         codeLensItem,
@@ -133,7 +133,7 @@ export abstract class AbstractCodeLensProvider {
 
   makeUpdateDependenciesCommand(codeLensItem) {
     codeLensItem.command = {
-      title: '&uarr; Update all',
+      title: `${this.appConfig.updateIndicator} Update all`,
       command: `_${this.appConfig.extentionName}.updateDependenciesCommand`,
       arguments: []
     };

--- a/test/unit/providers/abstractCodeLensProvider.tests.js
+++ b/test/unit/providers/abstractCodeLensProvider.tests.js
@@ -68,7 +68,7 @@ describe("AbstractCodeLensProvider", () => {
     it("when local ranged version does not satisfy the server version then codeLens should return NewVersionCommand", () => {
       defaultVersionPrefix = '^';
       const testLens = testProvider.makeTestVersionCommand('1.0.0 - 2.0.0', '2.8.0');
-      assert.equal(testLens.command.title, '&uarr; ^2.8.0', "Expected command.title failed.");
+      assert.equal(testLens.command.title, '⬆ ^2.8.0', "Expected command.title failed.");
       assert.equal(testLens.command.command, '_versionlens.updateDependencyCommand');
       assert.equal(testLens.command.arguments[1], '"^2.8.0"');
     });
@@ -76,7 +76,7 @@ describe("AbstractCodeLensProvider", () => {
     it("when local ranged version does not satisfy the server version then codeLens should return NewVersionCommand", () => {
       defaultVersionPrefix = '^';
       const testLens = testProvider.makeTestVersionCommand('1.0.0 - 2.0.0', '2.8.0');
-      assert.equal(testLens.command.title, '&uarr; ^2.8.0', "Expected command.title failed.");
+      assert.equal(testLens.command.title, '⬆ ^2.8.0', "Expected command.title failed.");
       assert.equal(testLens.command.command, '_versionlens.updateDependencyCommand');
       assert.equal(testLens.command.arguments[1], '"^2.8.0"');
     });
@@ -92,7 +92,7 @@ describe("AbstractCodeLensProvider", () => {
     it("when local version has caret and doesnt satisfies the server version then codeLens should return NewVersionCommand", () => {
       defaultVersionPrefix = '^';
       const testLens = testProvider.makeTestVersionCommand('^1.8.0', '2.8.0');
-      assert.equal(testLens.command.title, '&uarr; ^2.8.0', "Expected command.title failed.");
+      assert.equal(testLens.command.title, '⬆ ^2.8.0', "Expected command.title failed.");
       assert.equal(testLens.command.command, '_versionlens.updateDependencyCommand');
       assert.equal(testLens.command.arguments[1], '"^2.8.0"');
     });
@@ -108,7 +108,7 @@ describe("AbstractCodeLensProvider", () => {
     it("when local version has caret and satisfies the server version then codeLens should return SatisfiedWithNewerCommand", () => {
       defaultVersionPrefix = '^';
       const testLens = testProvider.makeTestVersionCommand('^2.0.0', '2.8.0');
-      assert.equal(testLens.command.title, '&uarr; satisfies v2.8.0', "Expected command.title failed.");
+      assert.equal(testLens.command.title, '⬆ satisfies v2.8.0', "Expected command.title failed.");
       assert.equal(testLens.command.command, '_versionlens.updateDependencyCommand');
       assert.equal(testLens.command.arguments[1], '"^2.8.0"');
     });
@@ -116,7 +116,7 @@ describe("AbstractCodeLensProvider", () => {
     it("when local version does not satisfy the server version then codeLens should return NewVersionCommand", () => {
       defaultVersionPrefix = '^';
       const testLens = testProvider.makeTestVersionCommand('1.0.0', '2.8.0');
-      assert.equal(testLens.command.title, '&uarr; ^2.8.0', "Expected command.title failed.");
+      assert.equal(testLens.command.title, '⬆ ^2.8.0', "Expected command.title failed.");
       assert.equal(testLens.command.command, '_versionlens.updateDependencyCommand');
       assert.equal(testLens.command.arguments[1], '"^2.8.0"');
     });

--- a/test/unit/providers/bowerCodeLensProvider.tests.js
+++ b/test/unit/providers/bowerCodeLensProvider.tests.js
@@ -160,7 +160,7 @@ describe("BowerCodeLensProvider", () => {
       };
 
       testProvider.resolveCodeLens(codeLens, null).then(result => {
-        assert.equal(result.command.title, '&uarr; ^3.2.1');
+        assert.equal(result.command.title, '⬆ ^3.2.1');
         assert.equal(result.command.command, '_versionlens.updateDependencyCommand');
         assert.equal(result.command.arguments[1], '"^3.2.1"');
         done();

--- a/test/unit/providers/dubCodeLensProvider.tests.js
+++ b/test/unit/providers/dubCodeLensProvider.tests.js
@@ -173,7 +173,7 @@ describe("DubCodeLensProvider", () => {
         });
       };
       testProvider.resolveCodeLens(codeLens, null).then(result => {
-        assert.equal(result.command.title, '&uarr; ^3.2.1');
+        assert.equal(result.command.title, '⬆ ^3.2.1');
         assert.equal(result.command.command, '_versionlens.updateDependencyCommand');
         assert.equal(result.command.arguments[1], '"^3.2.1"');
         done();

--- a/test/unit/providers/npmCodeLensProvider.tests.js
+++ b/test/unit/providers/npmCodeLensProvider.tests.js
@@ -184,7 +184,7 @@ describe("NpmCodeLensProvider", () => {
         });
       };
       testProvider.resolveCodeLens(codeLens, null).then(result => {
-        assert.equal(result.command.title, '&uarr; ^3.2.1');
+        assert.equal(result.command.title, '⬆ ^3.2.1');
         assert.equal(result.command.command, '_versionlens.updateDependencyCommand');
         assert.equal(result.command.arguments[1], '"^3.2.1"');
         done();


### PR DESCRIPTION
Fixes upcoming html escape change in vscode 1.7. See https://github.com/Microsoft/vscode/issues/13714