### PR TITLE
Adds ability to update all dependencies

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -7,6 +7,8 @@ import { AppConfiguration } from './common/appConfiguration';
 import { CommandFactory } from './providers/commandFactory';
 import { GithubRequest } from './common/githubRequest';
 
+import * as path from 'path';
+import * as fs from 'fs';
 import * as semver from 'semver';
 import * as jsonParser from 'vscode-contrib-jsonc';
 import * as httpRequest from 'request-light';
@@ -14,6 +16,8 @@ import * as npm from 'npm';
 import * as bower from 'bower';
 
 // external lib dependencies
+register('path', path);
+register('fs', fs);
 register('semver', semver);
 register('bower', bower);
 register('npm', npm);

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,31 +7,31 @@ import * as path from 'path';
 import * as opener from 'opener';
 
 export function updateDependencyCommand(codeLens, packageVersion) {
-    const edits = [TextEdit.replace(codeLens.versionRange, packageVersion)];
-    const edit = new WorkspaceEdit();
-    edit.set(codeLens.documentUrl, edits);
-    return workspace.applyEdit(edit);
+  const edits = [TextEdit.replace(codeLens.versionRange, packageVersion)];
+  const edit = new WorkspaceEdit();
+  edit.set(codeLens.documentUrl, edits);
+  return workspace.applyEdit(edit);
 }
 
 export function linkCommand(codeLens) {
-    if (codeLens.package.meta.type === 'file') {
-        const filePathToOpen = path.resolve(path.dirname(codeLens.documentUrl.fsPath), codeLens.package.meta.remoteUrl);
-        opener(filePathToOpen);
-        return;
-    }
-    opener(codeLens.package.meta.remoteUrl);
+  if (codeLens.package.meta.type === 'file') {
+    const filePathToOpen = path.resolve(path.dirname(codeLens.documentUrl.fsPath), codeLens.package.meta.remoteUrl);
+    opener(filePathToOpen);
+    return;
+  }
+  opener(codeLens.package.meta.remoteUrl);
 }
 
 export function updateDependenciesCommand(rootCodeLens, codeLenCollection) {
-    const edits = codeLenCollection
-        .filter(codeLens => codeLens != rootCodeLens)
-        .filter(codeLens => rootCodeLens.range.contains(codeLens.range))
-        .filter(codeLens => codeLens.command && codeLens.command.arguments)
-        .filter(codeLens => codeLens.package)
-        .filter(codeLens => !codeLens.package.meta || (codeLens.package.meta.type !== 'github' && codeLens.package.meta.type !== 'file'))
-        .map(codeLens => TextEdit.replace(codeLens.versionRange, codeLens.command.arguments[1]));
+  const edits = codeLenCollection
+    .filter(codeLens => codeLens != rootCodeLens)
+    .filter(codeLens => rootCodeLens.range.contains(codeLens.range))
+    .filter(codeLens => codeLens.command && codeLens.command.arguments)
+    .filter(codeLens => codeLens.package)
+    .filter(codeLens => !codeLens.package.meta || (codeLens.package.meta.type !== 'github' && codeLens.package.meta.type !== 'file'))
+    .map(codeLens => TextEdit.replace(codeLens.versionRange, codeLens.command.arguments[1]));
 
-    const edit = new WorkspaceEdit();
-    edit.set(rootCodeLens.documentUrl, edits);
-    return workspace.applyEdit(edit);
+  const edit = new WorkspaceEdit();
+  edit.set(rootCodeLens.documentUrl, edits);
+  return workspace.applyEdit(edit);
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,21 +7,31 @@ import * as path from 'path';
 import * as opener from 'opener';
 
 export function updateDependencyCommand(codeLens, packageVersion) {
-  const edits = [TextEdit.replace(codeLens.versionRange, packageVersion)];
-  const edit = new WorkspaceEdit();
-  edit.set(codeLens.package.meta.localUrl, edits);
-  return workspace.applyEdit(edit);
+    const edits = [TextEdit.replace(codeLens.versionRange, packageVersion)];
+    const edit = new WorkspaceEdit();
+    edit.set(codeLens.documentUrl, edits);
+    return workspace.applyEdit(edit);
 }
 
 export function linkCommand(codeLens) {
-  if (codeLens.package.meta.type === 'file') {
-    const filePathToOpen = path.resolve(path.dirname(codeLens.package.meta.localUrl.fsPath), codeLens.package.meta.remoteUrl);
-    opener(filePathToOpen);
-    return;
-  }
-  opener(codeLens.package.meta.remoteUrl);
+    if (codeLens.package.meta.type === 'file') {
+        const filePathToOpen = path.resolve(path.dirname(codeLens.documentUrl.fsPath), codeLens.package.meta.remoteUrl);
+        opener(filePathToOpen);
+        return;
+    }
+    opener(codeLens.package.meta.remoteUrl);
 }
 
-// export function updateDependenciesCommand(codeLens, packageVersion) {
+export function updateDependenciesCommand(rootCodeLens, codeLenCollection) {
+    const edits = codeLenCollection
+        .filter(codeLens => codeLens != rootCodeLens)
+        .filter(codeLens => rootCodeLens.range.contains(codeLens.range))
+        .filter(codeLens => codeLens.command && codeLens.command.arguments)
+        .filter(codeLens => codeLens.package)
+        .filter(codeLens => !codeLens.package.meta || (codeLens.package.meta.type !== 'github' && codeLens.package.meta.type !== 'file'))
+        .map(codeLens => TextEdit.replace(codeLens.versionRange, codeLens.command.arguments[1]));
 
-// }
+    const edit = new WorkspaceEdit();
+    edit.set(rootCodeLens.documentUrl, edits);
+    return workspace.applyEdit(edit);
+}

--- a/src/common/packageCodeLens.js
+++ b/src/common/packageCodeLens.js
@@ -7,22 +7,28 @@ import { extractSymbolFromVersionRegex, formatWithExistingLeading } from './util
 
 export class PackageCodeLens extends CodeLens {
 
-  constructor(
-    entryRange,
-    versionRange,
-    packageInfo,
-    customGenerateVersion
-  ) {
+  constructor(entryRange, versionRange, packageInfo, documentUrl) {
     super(entryRange);
     this.versionRange = versionRange || entryRange;
     this.package = packageInfo;
-    this.customGenerateVersion = customGenerateVersion;
+    this.documentUrl = documentUrl;
+    this.command = null;
   }
 
   generateNewVersion(newVersion) {
-    if(!this.customGenerateVersion) 
+    if (!this.package.customGenerateVersion)
       return formatWithExistingLeading(this.package.version, newVersion);
-    
-    return this.customGenerateVersion.call(this, this.package, newVersion);
+
+    return this.package.customGenerateVersion.call(this, this.package, newVersion);
   }
+
+  setCommand(text, command, args) {
+    this.command = {
+      title: text,
+      command: command || null,
+      arguments: args || null
+    };
+    return this;
+  }
+
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -39,6 +39,10 @@ export function activate(context) {
       updateDependencyCommand
     ),
     commands.registerCommand(
+      `_${config.extentionName}.updateDependenciesCommand`,
+      updateDependenciesCommand
+    ),
+    commands.registerCommand(
       `_${config.extentionName}.linkCommand`,
       linkCommand
     )

--- a/src/providers/abstractCodeLensProvider.js
+++ b/src/providers/abstractCodeLensProvider.js
@@ -21,10 +21,21 @@ export abstract class AbstractCodeLensProvider {
 
   collectDependencies_(collector, rootNode, customVersionParser) {
     rootNode.getChildNodes()
-      .forEach(node => {
-        const testDepProperty = node.key.value;
-        if (this.packageDependencyKeys.includes(testDepProperty))
-          collector.addRange(node.value.getChildNodes(), customVersionParser);
+      .forEach(childNode => {
+        if (this.packageDependencyKeys.includes(childNode.key.value) == false)
+          return;
+
+        const childDeps = childNode.value.getChildNodes();
+        // check if this node has entries and if so add the update all command
+        if (childDeps.length > 0)
+          this.commandFactory.makeUpdateDependenciesCommand(
+            childNode.key.value,
+            collector.addNode(childNode),
+            collector.collection
+          );
+
+        // collect all child dependencies
+        collector.addDependencyNodeRange(childDeps, customVersionParser);
       });
   }
 

--- a/src/providers/commandFactory.js
+++ b/src/providers/commandFactory.js
@@ -8,29 +8,24 @@ import { stripSymbolFromVersionRegex, semverLeadingChars } from '../common/utils
 @inject('semver', 'githubRequest', 'appConfig')
 export class CommandFactory {
 
-  makeErrorCommand(errorMsg, codeLensItem) {
-    codeLensItem.command = {
-      title: `${errorMsg}`,
-      command: undefined,
-      arguments: undefined
-    };
-    return codeLensItem;
+  makeErrorCommand(errorMsg, codeLens) {
+    return codeLens.setCommand(`${errorMsg}`);
   }
 
-  makeVersionCommand(localVersion, serverVersion, codeLensItem) {
+  makeVersionCommand(localVersion, serverVersion, codeLens) {
     const isLocalValid = this.semver.valid(localVersion);
     const isLocalValidRange = this.semver.validRange(localVersion);
     const isServerValid = this.semver.valid(serverVersion);
     const isServerValidRange = this.semver.validRange(serverVersion);
 
     if (!isLocalValid && !isLocalValidRange && localVersion !== 'latest')
-      return this.makeErrorCommand("Invalid semver version entered", codeLensItem);
+      return this.makeErrorCommand("Invalid semver version entered", codeLens);
 
     if (!isServerValid && !isServerValidRange && serverVersion !== 'latest')
-      return this.makeErrorCommand("Invalid semver server version received, " + serverVersion, codeLensItem);
+      return this.makeErrorCommand("Invalid semver server version received, " + serverVersion, codeLens);
 
     if (localVersion === 'latest')
-      return this.makeLatestCommand(codeLensItem);
+      return this.makeLatestCommand(codeLens);
 
     if (isLocalValidRange && !isLocalValid) {
       if (this.semver.satisfies(serverVersion, localVersion)) {
@@ -38,137 +33,104 @@ export class CommandFactory {
           let matches = stripSymbolFromVersionRegex.exec(localVersion);
           let cleanLocalVersion = (matches && matches[1]) || this.semver.clean(localVersion) || localVersion;
           if (cleanLocalVersion && this.semver.eq(serverVersion, cleanLocalVersion)) {
-            return this.makeSatisfiedCommand(serverVersion, codeLensItem);
+            return this.makeSatisfiedCommand(serverVersion, codeLens);
           }
         } catch (ex) {
-          return this.makeSatisfiedCommand(serverVersion, codeLensItem);
+          return this.makeSatisfiedCommand(serverVersion, codeLens);
         }
-        return this.makeSatisfiedWithNewerCommand(serverVersion, codeLensItem);
+        return this.makeSatisfiedWithNewerCommand(serverVersion, codeLens);
       }
       else
-        return this.makeNewVersionCommand(serverVersion, codeLensItem)
+        return this.makeNewVersionCommand(serverVersion, codeLens)
     }
 
     const hasNewerVersion = this.semver.gt(serverVersion, localVersion) === true
       || this.semver.lt(serverVersion, localVersion) === true;
 
     if (serverVersion !== localVersion && hasNewerVersion)
-      return this.makeNewVersionCommand(serverVersion, codeLensItem)
+      return this.makeNewVersionCommand(serverVersion, codeLens)
 
-    return this.makeLatestCommand(codeLensItem);
+    return this.makeLatestCommand(codeLens);
   }
 
-  makeNewVersionCommand(newVersion, codeLensItem) {
+  makeNewVersionCommand(newVersion, codeLens) {
     const prefix = this.appConfig.versionPrefix;
-    let replaceWithVersion = codeLensItem.generateNewVersion(newVersion);
-    if (!replaceWithVersion.startsWith(prefix)) {
+    let replaceWithVersion = codeLens.generateNewVersion(newVersion);
+    if (!replaceWithVersion.startsWith(prefix))
       replaceWithVersion = `${prefix}${replaceWithVersion}`
-    }
 
-    codeLensItem.command = {
-      title: `${this.appConfig.updateIndicator} ${this.appConfig.versionPrefix}${newVersion}`,
-      command: `_${this.appConfig.extentionName}.updateDependencyCommand`,
-      arguments: [
-        codeLensItem,
-        `"${replaceWithVersion}"`
-      ]
-    };
-    return codeLensItem;
+    return codeLens.setCommand(
+      `${this.appConfig.updateIndicator} ${this.appConfig.versionPrefix}${newVersion}`,
+      `_${this.appConfig.extentionName}.updateDependencyCommand`,
+      [codeLens, `"${replaceWithVersion}"`]
+    );
   }
 
-  makeSatisfiedCommand(serverVersion, codeLensItem) {
-    codeLensItem.command = {
-      title: `satisfies v${serverVersion}`,
-      command: undefined,
-      arguments: undefined
-    };
-    return codeLensItem;
+  makeSatisfiedCommand(serverVersion, codeLens) {
+    return codeLens.setCommand(`satisfies v${serverVersion}`);
   }
 
-  makeSatisfiedWithNewerCommand(serverVersion, codeLensItem) {
+  makeSatisfiedWithNewerCommand(serverVersion, codeLens) {
     const prefix = this.appConfig.versionPrefix;
-    let replaceWithVersion = codeLensItem.generateNewVersion(serverVersion);
-    if (!replaceWithVersion.startsWith(prefix)) {
+    let replaceWithVersion = codeLens.generateNewVersion(serverVersion);
+    if (!replaceWithVersion.startsWith(prefix))
       replaceWithVersion = `${prefix}${replaceWithVersion}`
-    }
 
-    codeLensItem.command = {
-      title: `${this.appConfig.updateIndicator} satisfies v${serverVersion}`,
-      command: `_${this.appConfig.extentionName}.updateDependencyCommand`,
-      arguments: [
-        codeLensItem,
-        `"${replaceWithVersion}"`
-      ]
-    };
-    return codeLensItem;
+    return codeLens.setCommand(
+      `${this.appConfig.updateIndicator} satisfies v${serverVersion}`,
+      `_${this.appConfig.extentionName}.updateDependencyCommand`,
+      [codeLens, `"${replaceWithVersion}"`]
+    );
   }
 
-  makeLatestCommand(codeLensItem) {
-    codeLensItem.command = {
-      title: 'latest',
-      command: undefined,
-      arguments: undefined
-    };
-    return codeLensItem;
+  makeLatestCommand(codeLens) {
+    return codeLens.setCommand('latest');
   }
 
-  makeTagCommand(tag, codeLensItem) {
-    codeLensItem.command = {
-      title: tag,
-      command: undefined,
-      arguments: undefined
-    };
-    return codeLensItem;
+  makeTagCommand(tag, codeLens) {
+    return codeLens.setCommand(tag);
   }
 
-  makeUpdateDependenciesCommand(codeLensItem) {
-    codeLensItem.command = {
-      title: `${this.appConfig.updateIndicator} Update all`,
-      command: `_${this.appConfig.extentionName}.updateDependenciesCommand`,
-      arguments: []
-    };
-    return codeLensItem;
+  makeUpdateDependenciesCommand(propertyName, codeLens, codeLenCollection) {
+    return codeLens.setCommand(
+      `${this.appConfig.updateIndicator} Update ${propertyName}`,
+      `_${this.appConfig.extentionName}.updateDependenciesCommand`,
+      [codeLens, codeLenCollection]
+    );
   }
 
-  makeLinkCommand(codeLensItem) {
-    codeLensItem.command = {
-      title: `${this.appConfig.openNewWindowIndicator} ` + (codeLensItem.package.meta.type === 'file' ?
-        codeLensItem.package.version :
-        codeLensItem.package.meta.remoteUrl),
-      command: `_${this.appConfig.extentionName}.linkCommand`,
-      arguments: [
-        codeLensItem
-      ]
-    };
-    return codeLensItem;
+  makeLinkCommand(codeLens) {
+    return codeLens.setCommand(
+      `${this.appConfig.openNewWindowIndicator} ` + (codeLens.package.meta.type === 'file' ?
+        codeLens.package.version :
+        codeLens.package.meta.remoteUrl),
+      `_${this.appConfig.extentionName}.linkCommand`,
+      [codeLens]
+    );
   }
 
-  makeGithubCommand(codeLensItem) {
-    const meta = codeLensItem.package.meta;
+  makeGithubCommand(codeLens) {
+    const meta = codeLens.package.meta;
 
     return this.githubRequest[`getLatest${meta.category}`](meta.userRepo)
       .then(entry => {
         if (!entry)
-          return this.makeTagCommand(`${meta.category}: none`, codeLensItem);
+          return this.makeTagCommand(`${meta.category}: none`, codeLens);
 
         if (meta.commitish === '' ||
           (semverLeadingChars.includes(meta.commitish[0]) ? meta.commitish[0] : '') + entry.version === meta.commitish)
-          return this.makeTagCommand(`${meta.category}: latest`, codeLensItem);
+          return this.makeTagCommand(`${meta.category}: latest`, codeLens);
 
-        const newVersion = codeLensItem.generateNewVersion(entry.version);
-        codeLensItem.command = {
-          title: `${meta.category}: ${this.appConfig.updateIndicator} ${entry.version}`,
-          command: `_${this.appConfig.extentionName}.updateDependencyCommand`,
-          arguments: [
-            codeLensItem,
-            `"${newVersion}"`
-          ]
-        };
-        return codeLensItem;
+        const newVersion = codeLens.generateNewVersion(entry.version);
+        return codeLens.setCommand(
+          `${meta.category}: ${this.appConfig.updateIndicator} ${entry.version}`,
+          `_${this.appConfig.extentionName}.updateDependencyCommand`,
+          [codeLens, `"${newVersion}"`]
+        );
       })
       .catch(error => {
         if (error.rateLimitExceeded)
-          return this.makeTagCommand(`Rate limit exceeded`, codeLensItem);
+          return this.makeTagCommand(`Rate limit exceeded`, codeLens);
 
         return Promise.reject(error);
       });

--- a/src/providers/npm/npmCodeLensProvider.js
+++ b/src/providers/npm/npmCodeLensProvider.js
@@ -41,6 +41,7 @@ export class NpmCodeLensProvider extends AbstractCodeLensProvider {
       return [];
 
     const collector = new PackageCodeLensList(document, this.appConfig);
+
     this.collectDependencies_(collector, jsonDoc.root, npmVersionParser);
     this.collectExtensionDependencies_(collector, jsonDoc.root);
     return collector.collection;
@@ -48,6 +49,9 @@ export class NpmCodeLensProvider extends AbstractCodeLensProvider {
 
   resolveCodeLens(codeLensItem, token) {
     if (codeLensItem instanceof PackageCodeLens) {
+      if (codeLensItem.command)
+        return codeLensItem;
+
       if (codeLensItem.package.version === 'latest')
         return this.commandFactory.makeLatestCommand(codeLensItem);
 

--- a/test/unit/providers/bower/bowerCodeLensProvider.tests.js
+++ b/test/unit/providers/bower/bowerCodeLensProvider.tests.js
@@ -88,11 +88,12 @@ describe("BowerCodeLensProvider", () => {
 
       let codeLens = testProvider.provideCodeLenses(testDocument, null);
       assert.ok(codeLens instanceof Array, "codeLens should be an array.");
-      assert.equal(codeLens.length, 4, "codeLens should be an array containing 4 items.");
+      assert.equal(codeLens.length, 5, "codeLens should be an array containing 5 items inc <update all>.");
 
-      codeLens.forEach((entry, index) => {
-        assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
-      });
+      codeLens.slice(1)
+        .forEach((entry, index) => {
+          assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
+        });
     });
   });
 

--- a/test/unit/providers/dub/dubCodeLensProvider.tests.js
+++ b/test/unit/providers/dub/dubCodeLensProvider.tests.js
@@ -87,11 +87,12 @@ describe("DubCodeLensProvider", () => {
 
       let codeLens = testProvider.provideCodeLenses(testDocument, null);
       assert.ok(codeLens instanceof Array, "codeLens should be an array.");
-      assert.equal(codeLens.length, 4, "codeLens should be an array containing 4 items.");
+      assert.equal(codeLens.length, 5, "codeLens should be an array containing 5 items inc <update all>.");
 
-      codeLens.forEach((entry, index) => {
-        assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
-      });
+      codeLens.slice(1)
+        .forEach((entry, index) => {
+          assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
+        });
     });
 
   });

--- a/test/unit/providers/npm/npmCodeLensProvider.tests.js
+++ b/test/unit/providers/npm/npmCodeLensProvider.tests.js
@@ -88,11 +88,12 @@ describe("NpmCodeLensProvider", () => {
 
       let codeLens = testProvider.provideCodeLenses(testDocument, null);
       assert.ok(codeLens instanceof Array, "codeLens should be an array.");
-      assert.equal(codeLens.length, 4, "codeLens should be an array containing 4 items.");
+      assert.equal(codeLens.length, 5, "codeLens should be an array containing 5 items inc <update all>.");
 
-      codeLens.forEach((entry, index) => {
-        assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
-      });
+      codeLens.slice(1)
+        .forEach((entry, index) => {
+          assert.equal(entry.package.name, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
+        });
     });
 
   });


### PR DESCRIPTION
Can now choose to update all packages within a dependency section. i.e. update all beneath `devDependencies`. 
Note: This functionality ignores github and file package entries.
Note: Because code len's are not generated until they are in view then only code len's that have been viewed since opening the document will be updated.

`file:<path>` links are now checked for existence and gives indication if they don't exist
