### PR TITLE
Github improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
     **Note**
 
-      - Because code len's are not generated until they are viewed in the editor then only code len's that have been viewed since opening the document can be updated. 
+      - Because code lenses are not generated until they are viewed in the editor then only code lenses that have been viewed since opening the document can be updated. 
         If you have many dependencies that go off the screen then just scroll them all in to view once before running the update all command for maximum coverage.
       - This functionality ignores github and file package entries.
 

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "dependencies": {
     "bower": "1.8.0",
-    "npm": "3.10.9",
+    "npm": "4.0.2",
     "opener": "1.4.2",
     "request-light": "0.1",
     "semver": "5.3.0",
     "vscode-contrib-jsonc": "1.0.0-beta.2",
-    "vscode-languageclient": "2.6.2"
+    "vscode-languageclient": "2.6.3"
   },
   "contributes": {
     "configuration": {
@@ -77,6 +77,11 @@
             "Commit"
           ],
           "description": "Defines what commit types are used when comparing github packages. *A minumum of one commit type must be specified.*"
+        },
+        "versionlens.github.accessToken": {
+          "type": "string",
+          "default": "",
+          "description": "Used for making basic read only github api requests. To generate a token see https://help.github.com/articles/creating-an-access-token-for-command-line-use/#creating-a-token. When no token is provided then access to the github api is rate limited to 60 requests every 10 minutes or so."
         }
       }
     }

--- a/src/common/appConfiguration.js
+++ b/src/common/appConfiguration.js
@@ -20,6 +20,11 @@ export class AppConfiguration {
     return config.get('github.compareOptions', ['Release', 'Tag', 'Commit']);
   }
 
+  get githubAccessToken() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get('github.accessToken', null);
+  }
+
   get updateIndicator() {
     return '⬆';
   }

--- a/src/common/githubRequest.js
+++ b/src/common/githubRequest.js
@@ -72,17 +72,23 @@ export class GithubRequest {
       .catch(response => {
         const error = JSON.parse(response.responseText);
         // handles any 404 errors during a request for the latest release
-        if (response.status = 404 && category == "releases/latest") {
+        if (response.status = 404 && category === 'releases/latest') {
           return this.cache.set(
             url,
             null
           );
         }
 
+        // check if the request was not found and report back
+        error.notFound = (
+          response.status = 404 &&
+          error.message.includes('Not Found')
+        );
+
         // check if we have exceeded the rate limit
         error.rateLimitExceeded = (
           response.status = 403 &&
-          error.message.indexOf('API rate limit exceeded') > -1
+          error.message.includes('API rate limit exceeded')
         );
 
         // reject all other errors

--- a/src/providers/commandFactory.js
+++ b/src/providers/commandFactory.js
@@ -119,8 +119,9 @@ export class CommandFactory {
 
   makeGithubCommand(codeLens) {
     const meta = codeLens.package.meta;
+    const fnName = `getLatest${meta.category}`;
 
-    return this.githubRequest[`getLatest${meta.category}`](meta.userRepo)
+    return this.githubRequest[fnName](meta.userRepo)
       .then(entry => {
         if (!entry)
           return this.makeTagCommand(`${meta.category}: none`, codeLens);
@@ -138,7 +139,10 @@ export class CommandFactory {
       })
       .catch(error => {
         if (error.rateLimitExceeded)
-          return this.makeTagCommand(`Rate limit exceeded`, codeLens);
+          return this.makeTagCommand('Rate limit exceeded', codeLens);
+
+        if (error.notFound)
+          return this.makeTagCommand('Resource not found', codeLens);
 
         return Promise.reject(error);
       });

--- a/test/smoke/npm/package.json
+++ b/test/smoke/npm/package.json
@@ -3,7 +3,7 @@
   "title": "smoke test",
   "dependencies": {},
   "devDependencies": {
-    "micro-tasks": "pflannery/micro-tasks#f43a971",
+    "bootstrap": "twbs/bootstrap#v3.3.0",
     "test": "file:../../../src",
     "@types/angularjs": "^1.5.14-alpha",
     "@types/fs-extra": "0.0.34"


### PR DESCRIPTION
- Adds ability to provide github access token

  Tokens can be provided by setting `versionlens.github.accessToken`. To generate a token see   https://help.github.com/articles/creating-an-access-token-for-command-line-use/#creating-a-token
  
  When no token is provided then access to the api will be rate limited to 60 requests every 10 minutes or so.

- Adds indication for github packages that dont exist

closes #28 