### PR TITLE
Dependency properties can now be defined via config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,59 @@
           "default": "",
           "description": "Inserts this prefix before the version when clicking on the code lens link."
         },
+        "versionlens.npm.dependencyProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "minItems": 1,
+          "default": [
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies"
+          ],
+          "description": "Defines which properties in package.json should be parsed by this extension"
+        },
+        "versionlens.bower.dependencyProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "minItems": 1,
+          "default": [
+            "dependencies",
+            "devDependencies"
+          ],
+          "description": "Defines which properties in bower.json should be parsed by this extension"
+        },
+        "versionlens.dotnet.dependencyProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "minItems": 1,
+          "default": [
+            "dependencies",
+            "tools"
+          ],
+          "description": "Defines which properties in project.json should be parsed by this extension"
+        },
+        "versionlens.dub.dependencyProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "minItems": 1,
+          "default": [
+            "dependencies"
+          ],
+          "description": "Defines which properties in dub.json should be parsed by this extension"
+        },
         "versionlens.github.compareOptions": {
           "type": "array",
           "items": {
@@ -69,6 +122,7 @@
               "Commit"
             ]
           },
+          "uniqueItems": true,
           "minItems": 1,
           "maxItems": 3,
           "default": [

--- a/src/common/appConfiguration.js
+++ b/src/common/appConfiguration.js
@@ -3,6 +3,10 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { workspace } from 'vscode';
+import { npmDefaultDependencyProperties } from '../providers/npm/config';
+import { bowerDefaultDependencyProperties } from '../providers/bower/config';
+import { dotnetDefaultDependencyProperties } from '../providers/dotnet/config';
+import { dubDefaultDependencyProperties } from '../providers/dub/config';
 
 export class AppConfiguration {
 
@@ -13,6 +17,26 @@ export class AppConfiguration {
   get versionPrefix() {
     const config = workspace.getConfiguration('versionlens');
     return config.get("versionPrefix", "");
+  }
+
+  get npmDependencyProperties() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("npm.dependencyProperties", npmDefaultDependencyProperties);
+  }
+
+  get bowerDependencyProperties() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("bower.dependencyProperties", bowerDefaultDependencyProperties);
+  }
+
+  get dotnetDependencyProperties() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("dotnet.dependencyProperties", dotnetDefaultDependencyProperties);
+  }
+
+  get dubDependencyProperties() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("dub.dependencyProperties", dubDefaultDependencyProperties);
   }
 
   get githubCompareOptions() {

--- a/src/providers/abstractCodeLensProvider.js
+++ b/src/providers/abstractCodeLensProvider.js
@@ -22,7 +22,7 @@ export abstract class AbstractCodeLensProvider {
   collectDependencies_(collector, rootNode, customVersionParser) {
     rootNode.getChildNodes()
       .forEach(childNode => {
-        if (this.packageDependencyKeys.includes(childNode.key.value) == false)
+        if (this.getPackageDependencyKeys().includes(childNode.key.value) == false)
           return;
 
         const childDeps = childNode.value.getChildNodes();

--- a/src/providers/bower/bowerCodeLensProvider.js
+++ b/src/providers/bower/bowerCodeLensProvider.js
@@ -8,12 +8,8 @@ import { PackageCodeLensList } from '../../common/packageCodeLensList';
 import { AbstractCodeLensProvider } from '../abstractCodeLensProvider';
 import { bowerVersionParser } from './bowerVersionParser';
 
-@inject('jsonParser', 'bower', 'appConfig')
+@inject('jsonParser', 'bower')
 export class BowerCodeLensProvider extends AbstractCodeLensProvider {
-
-  constructor() {
-    this.packageDependencyKeys = ['dependencies', 'devDependencies'];
-  }
 
   get selector() {
     return {
@@ -21,7 +17,11 @@ export class BowerCodeLensProvider extends AbstractCodeLensProvider {
       scheme: 'file',
       pattern: '**/bower.json'
     }
-  };
+  }
+
+  getPackageDependencyKeys() {
+    return this.appConfig.bowerDependencyProperties;
+  }
 
   provideCodeLenses(document, token) {
     const jsonDoc = this.jsonParser.parse(document.getText());

--- a/src/providers/bower/config.js
+++ b/src/providers/bower/config.js
@@ -1,0 +1,4 @@
+export const bowerDefaultDependencyProperties = [
+  "dependencies",
+  "devDependencies"
+];

--- a/src/providers/dotnet/config.js
+++ b/src/providers/dotnet/config.js
@@ -1,0 +1,4 @@
+export const dotnetDefaultDependencyProperties = [
+  "dependencies",
+  "tools"
+];

--- a/src/providers/dub/config.js
+++ b/src/providers/dub/config.js
@@ -1,0 +1,3 @@
+export const dubDefaultDependencyProperties = [
+  "dependencies"
+];

--- a/src/providers/dub/dubCodeLensProvider.js
+++ b/src/providers/dub/dubCodeLensProvider.js
@@ -7,14 +7,8 @@ import { PackageCodeLens } from '../../common/packageCodeLens';
 import { PackageCodeLensList } from '../../common/packageCodeLensList';
 import { AbstractCodeLensProvider } from '../abstractCodeLensProvider';
 
-@inject('jsonParser', 'httpRequest', 'appConfig')
+@inject('jsonParser', 'httpRequest')
 export class DubCodeLensProvider extends AbstractCodeLensProvider {
-
-  constructor() {
-    this.packageDependencyKeys = [
-      'dependencies'
-    ];
-  }
 
   get selector() {
     return {
@@ -24,10 +18,15 @@ export class DubCodeLensProvider extends AbstractCodeLensProvider {
     };
   }
 
+  getPackageDependencyKeys() {
+    return this.appConfig.dubDependencyProperties;
+  }
+
   collectDependencies_(collector, rootNode, customVersionParser) {
+    const packageDependencyKeys = this.getPackageDependencyKeys();
     rootNode.getChildNodes()
       .forEach(childNode => {
-        if (this.packageDependencyKeys.includes(childNode.key.value)) {
+        if (packageDependencyKeys.includes(childNode.key.value)) {
           const childDeps = childNode.value.getChildNodes();
           // check if this node has entries and if so add the update all command
           if (childDeps.length > 0)

--- a/src/providers/npm/config.js
+++ b/src/providers/npm/config.js
@@ -1,0 +1,6 @@
+export const npmDefaultDependencyProperties = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies"
+];

--- a/test/smoke/.vscode/settings.json
+++ b/test/smoke/.vscode/settings.json
@@ -1,0 +1,10 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "versionlens.npm.dependencyProperties": [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "customDependencies"
+  ]
+}

--- a/test/smoke/npm/package.json
+++ b/test/smoke/npm/package.json
@@ -6,7 +6,11 @@
     "bootstrap": "twbs/bootstrap#v3.3.0",
     "test": "file:../../../src",
     "@types/angularjs": "^1.5.14-alpha",
-    "@types/fs-extra": "0.0.34"
+    "@types/fs-extra": "0.0.34",
+    "@angular": ""
+  },
+  "customDependencies": {
+    "@types/hammerjs": "2.0.1"
   },
   "jspm": {
     "directories": {

--- a/test/unit/providers/bower/bowerCodeLensProvider.tests.js
+++ b/test/unit/providers/bower/bowerCodeLensProvider.tests.js
@@ -10,6 +10,7 @@ import * as jsonParser from 'vscode-contrib-jsonc';
 import { register, clear } from '../../../../src/common/di';
 import { TestFixtureMap } from '../../../testUtils';
 import { BowerCodeLensProvider } from '../../../../src/providers/bower/bowerCodeLensProvider';
+import { bowerDefaultDependencyProperties } from '../../../../src/providers/bower/config';
 import { AppConfiguration } from '../../../../src/common/appConfiguration';
 import { CommandFactory } from '../../../../src/providers/commandFactory';
 import { PackageCodeLens } from '../../../../src/common/packageCodeLens';
@@ -22,6 +23,10 @@ describe("BowerCodeLensProvider", () => {
   let bowerMock;
   let testProvider;
 
+  let appConfigMock;
+  let defaultVersionPrefix = '^';
+  let bowerDependencyProperties = bowerDefaultDependencyProperties;
+
   beforeEach(() => {
     bowerMock = {
       commands: {
@@ -30,15 +35,17 @@ describe("BowerCodeLensProvider", () => {
     };
 
     clear();
+
+    appConfigMock = new AppConfiguration();
+    Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+    Object.defineProperty(appConfigMock, 'bowerDependencyProperties', { get: () => bowerDependencyProperties })
+
     register('bower', bowerMock);
     register('semver', semver);
     register('jsonParser', jsonParser);
-
-    // mock the config
-    const appConfig = register('appConfig', new AppConfiguration());
-    Object.defineProperty(appConfig, 'versionPrefix', { get: () => '^' })
-
+    register('appConfig', appConfigMock);
     register('commandFactory', new CommandFactory());
+
     testProvider = new BowerCodeLensProvider();
   });
 

--- a/test/unit/providers/dub/dubCodeLensProvider.tests.js
+++ b/test/unit/providers/dub/dubCodeLensProvider.tests.js
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { register, clear } from '../../../../src/common/di';
 import { TestFixtureMap } from '../../../testUtils';
 import { DubCodeLensProvider } from '../../../../src/providers/dub/dubCodeLensProvider';
+import { dubDefaultDependencyProperties } from '../../../../src/providers/dub/config';
 import { AppConfiguration } from '../../../../src/common/appConfiguration';
 import { PackageCodeLens } from '../../../../src/common/packageCodeLens';
 import { CommandFactory } from '../../../../src/providers/commandFactory';
@@ -23,12 +24,17 @@ describe("DubCodeLensProvider", () => {
 
   let testProvider;
   let httpRequestMock = {};
-  let appConfigMock = new AppConfiguration();
+  let appConfigMock;
   let defaultVersionPrefix;
-  Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+  let defaultDubDependencyKeys = dubDefaultDependencyProperties;
 
   beforeEach(() => {
     clear();
+
+    appConfigMock = new AppConfiguration();
+    Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+    Object.defineProperty(appConfigMock, 'dubDependencyProperties', { get: () => defaultDubDependencyKeys })
+
     register('semver', semver);
     register('jsonParser', jsonParser);
     register('httpRequest', httpRequestMock);

--- a/test/unit/providers/npm/npmCodeLensProvider.tests.js
+++ b/test/unit/providers/npm/npmCodeLensProvider.tests.js
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { register, clear } from '../../../../src/common/di';
 import { TestFixtureMap } from '../../../testUtils';
+import { npmDefaultDependencyProperties } from '../../../../src/providers/npm/config';
 import { NpmCodeLensProvider } from '../../../../src/providers/npm/npmCodeLensProvider';
 import { AppConfiguration } from '../../../../src/common/appConfiguration';
 import { PackageCodeLens } from '../../../../src/common/packageCodeLens';
@@ -25,17 +26,23 @@ describe("NpmCodeLensProvider", () => {
   let npmMock = {
     load: cb => cb()
   };
-  let appConfigMock = new AppConfiguration();
+  let appConfigMock;
   let defaultVersionPrefix;
-  Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+  let defaultNpmDependencyKeys = npmDefaultDependencyProperties;
 
   beforeEach(() => {
     clear();
+
+    appConfigMock = new AppConfiguration();
+    Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+    Object.defineProperty(appConfigMock, 'npmDependencyProperties', { get: () => defaultNpmDependencyKeys })
+
     register('semver', semver);
     register('jsonParser', jsonParser);
     register('npm', npmMock);
     register('appConfig', appConfigMock);
     register('commandFactory', new CommandFactory());
+
     // mock the config
     defaultVersionPrefix = '^';
     testProvider = new NpmCodeLensProvider();


### PR DESCRIPTION
Example

```json
// package.json
{
  "versionlens.npm.dependencyProperties": [
    "dependencies",
    "devDependencies",
    "peerDependencies",
    "optionalDependencies",
    "customDependencies"
  ]
}
```