### PR TITLE
Adds very basic support for dealing with dotnet pre-release packages

### DIFF
--- a/src/providers/commandFactory.js
+++ b/src/providers/commandFactory.js
@@ -13,7 +13,7 @@ export function makeErrorCommand(errorMsg, codeLens) {
   return codeLens.setCommand(`${errorMsg}`);
 }
 
-export function makeVersionCommand(localVersion, serverVersion, codeLens) {
+export function makeVersionCommand(localVersion, serverVersion, codeLens, latestServerVersion) {
   const isLocalValid = semver.valid(localVersion);
   const isLocalValidRange = semver.validRange(localVersion);
   const isServerValid = semver.valid(serverVersion);
@@ -52,13 +52,16 @@ export function makeVersionCommand(localVersion, serverVersion, codeLens) {
   if (serverVersion !== localVersion && hasNewerVersion)
     return makeNewVersionCommand(serverVersion, codeLens);
 
+  if (latestServerVersion !== undefined)
+    return makeNewVersionCommand(latestServerVersion, codeLens, 'Matches latest | ');
+
   return makeLatestCommand(codeLens);
 }
 
-export function makeNewVersionCommand(newVersion, codeLens) {
+export function makeNewVersionCommand(newVersion, codeLens, prefix = '') {
   const replaceWithVersion = codeLens.generateNewVersion(newVersion);
   return codeLens.setCommand(
-    `${codeLens.getTaggedVersionPrefix()}${appSettings.updateIndicator} ${newVersion}`,
+    `${codeLens.getTaggedVersionPrefix() || prefix}${appSettings.updateIndicator} ${newVersion}`,
     `${appSettings.extensionName}.updateDependencyCommand`,
     [codeLens, `"${replaceWithVersion}"`]
   );


### PR DESCRIPTION
Attempts to add VERY basic support for dealing with dotnet prerelease packages. Since the nuget api doesn't have any support for separating prerelease vs not, this takes an very naive approach.

Basically here are the "rules":
- if you are starting with a prerelease version 
  - we will just take the most recent server version -- nothing has changed
- if you are starting with a non-prerelease version 
  - and the most recent version is a non-prerelease version we will take that version -- nothing has changed
  - and the most recent version is a prerelease version, we will skip it (while noting it) and search for the most recent non-prerelease version
    - if the most recent non-prerelease is later than the current version, we will show an update lens with that version
    - if the most recent non-prerelease isn't later than the current version, we will show `Matches latest | ` plus an update lens with the truly most recent version

That way you can easily update a package to the latest "released" version, but also see that there is a later "pre-release" version **if** you are using the most recent "released" version 

I hope this makes sense. And while I think these changes are not ideal -- they have made a big difference in me being able to update my packages much more easily, because with the current logic, once there is a pre-release on nuget that's all you are going to see and it really kills the usefulness of version lens in that case.