### PR TITLE
Dub installation check using dub.selections.json

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -9,7 +9,7 @@ export const fileDependencyRegex = /^file:(.*)$/;
 export const gitHubDependencyRegex = /^\/?([^:\/\s]+)(\/)([\w\-\.]+[^#?\s]+)(.*)?(#[\w\-]+)?$/;
 export const stripSymbolFromVersionRegex = /^(?:[^0-9]+)?(.+)$/;
 export const extractSymbolFromVersionRegex = /^([^0-9]*)?.*$/;
-export const semverLeadingChars = ['^', '~', '<', '<=', '>', '>='];
+export const semverLeadingChars = ['^', '~', '<', '<=', '>', '>=', '~>'];
 
 export function formatWithExistingLeading(existingVersion, newVersion) {
   const regExResult = extractSymbolFromVersionRegex.exec(existingVersion);

--- a/src/providers/dub/dubCodeLensProvider.js
+++ b/src/providers/dub/dubCodeLensProvider.js
@@ -45,7 +45,7 @@ export class DubCodeLensProvider extends AbstractCodeLensProvider {
     if (!jsonDoc || !jsonDoc.root || jsonDoc.validationResult.errors.length > 0)
       return [];
 
-    const dubJson = document.uri.fsPath;
+    const dubJson = ((document.uri || {}).fsPath || "").toString();
 
     if (dubJson.endsWith(".json")) {
       // dub.json -> dub.selections.json
@@ -146,6 +146,9 @@ export class DubCodeLensProvider extends AbstractCodeLensProvider {
   generateDecoration(codeLens) {
     const currentPackageName = codeLens.package.name;
     const currentPackageVersion = codeLens.package.version;
+
+    if (!codeLens.range)
+      return;
 
     if (!this.selectionsJson) {
       updateDecoration(createMissingDecoration(codeLens.range));


### PR DESCRIPTION
Dub shows which packages are installed now:

![https://i.webfreak.org/fbKkrv.png](https://i.webfreak.org/fbKkrv.png)

This works by checking the dub.selections.json file which contains the resolved version numbers of the packages that are going to be installed if not already installed on compilation. While it might not actually be installed when it says it is installed, it will automatically install when you next compile so there shouldn't really be any difference there.

I also added `~>` as semver char in the version stripping because that's the default prefix you get inside the dub project templates and it is quite commonly used there.