### PR TITLE
Fixes #63 jspm version parsing can break code lens

### DIFF
--- a/src/common/codeLensGeneration.js
+++ b/src/common/codeLensGeneration.js
@@ -11,6 +11,9 @@ export function generateCodeLenses(packageCollection, document) {
     .then(results => {
       const codeLenses = [];
       results.forEach(entryOrEntries => {
+        if (entryOrEntries === undefined)
+          return;
+
         if (Array.isArray(entryOrEntries)) {
           entryOrEntries.forEach(
             (entry, order) => {

--- a/src/common/dependencyParser.js
+++ b/src/common/dependencyParser.js
@@ -52,8 +52,11 @@ export function parseDependencyNodes(dependencyNodes, appConfig, customVersionPa
     const node = dependencyNodes[i];
 
     const parsedResult;
-    if (customVersionParser)
+    if (customVersionParser) {
       parsedResult = customVersionParser(node, appConfig);
+      if (parsedResult === undefined)
+        continue;
+    }
     else
       parsedResult = { node };
 


### PR DESCRIPTION
If the jspm version contains any prefix other than npm: or github: no jspm code lens would have rendered