### PR TITLE
Fix a bug that occurs when a package only has prerelease versions

### DIFF
--- a/src/common/versionUtils.js
+++ b/src/common/versionUtils.js
@@ -296,9 +296,9 @@ export function buildTagsFromVersionMap(versionMap, requestedVersion) {
   // store the latest release
   const latestEntry = {
     name: "latest",
-    version: versionMap.releases[0],
+    version: versionMap.releases[0] || versionMap.taggedVersions[0].version,
     // can only be older if a match was found and requestedVersion is a valid range
-    isOlderThanRequested: !versionMatchNotFound && isRequestedVersionValid && isOlderVersion(versionMap.releases[0], requestedVersion)
+    isOlderThanRequested: !versionMatchNotFound && isRequestedVersionValid && isOlderVersion(versionMap.releases[0] || versionMap.taggedVersions[0].version, requestedVersion)
   };
   const satisfiesLatest = semver.satisfies(versionMap.maxSatisfyingVersion, latestEntry.version);
   const isFixed = isRequestedVersionValid && isFixedVersion(requestedVersion);

--- a/test/unit/common/versionsUtils.tests.js
+++ b/test/unit/common/versionsUtils.tests.js
@@ -676,8 +676,18 @@ export const VersionUtilTests = {
 
       assert.ok(resultTags[0].versionMatchNotFound === false, "Did not match a version that does exists")
       assert.ok(resultTags[0].isInvalid === false, "Version should not be flagged as invalid");
-    }
+    },
 
+    "does not fail if only prerelease versions": () => {
+      const requestedVersion = '2.1.0-preview1-final';
+      const testVersionMap = buildMapFromVersionList(['2.1.0-preview1-final'], requestedVersion);
+      const resultTags = buildTagsFromVersionMap(testVersionMap, requestedVersion);
+
+      assert.ok(resultTags[0].versionMatchNotFound === false, "Did not match a version that does exists");
+      assert.ok(resultTags[0].isInvalid === false, "Version should not be flagged as invalid");
+      assert.ok(resultTags[0].isLatestVersion === true, "Should be latest version");
+      assert.ok(resultTags[0].satisfiesLatest === true, "Should install latest version");
+    }
   },
 
   "applyTagFilterRules": {


### PR DESCRIPTION
This PR fixes #94 by falling back to the newest prerelease version if no release version is available.