### PR TITLE
Update npmPackageParser.js

### DIFF
--- a/src/providers/npm/npmPackageParser.js
+++ b/src/providers/npm/npmPackageParser.js
@@ -24,20 +24,21 @@ const semver = require('semver');
 
 export function npmPackageParser(name, requestedVersion, appContrib) {
   return parseNpmArguments(name, requestedVersion)
-    .then(npmVersionInfo => {
+    .then(npmVersionInfo => {   
+
       // check if we have a directory
-      if (npmVersionInfo.type === 'directory')
+      if (npmVersionInfo && npmVersionInfo.type === 'directory')
         return parseFileVersion(name, requestedVersion);
 
       // check if we have a github version
-      if (npmVersionInfo.type === 'git' && npmVersionInfo.hosted.type === 'github') {
+      if (npmVersionInfo && npmVersionInfo.type === 'git' && npmVersionInfo.hosted && npmVersionInfo.hosted.type === 'github') {
         return parseGithubVersion(
           name,
           npmVersionInfo.hosted.path({ noCommittish: false }),
           appContrib.githubTaggedCommits,
           customNpmGenerateVersion
         );
-      } else if (npmVersionInfo.type === 'git') {
+      } else if (npmVersionInfo && npmVersionInfo.type === 'git') {
         // TODO: implement raw git url support
         return PackageFactory.createPackageNotSupported(
           name,
@@ -172,7 +173,7 @@ export function customNpmGenerateVersion(packageInfo, newVersion) {
   let existingVersion
   // test if the newVersion is a valid semver range
   // if it is then we need to use the commitish for github versions 
-  if (packageInfo.meta.type === 'github' && semver.validRange(newVersion))
+  if (packageInfo && packageInfo.meta && packageInfo.meta.type === 'github' && semver.validRange(newVersion))
     existingVersion = packageInfo.meta.commitish
   else
     existingVersion = packageInfo.version


### PR DESCRIPTION
Resolves https://github.com/vscode-contrib/vscode-versionlens/issues/86
Stop assuming that the response will be an object and may be null.
This happens in the scenario where a private Git repo hosts a package.

It looks like this repo's admins are taking a long time to merge PRs, so, in the meanwhile, if you like me were stuck on this, here is what you can do : 
```
git clone git@github.com:sebastienfi/vscode-versionlens.git
cd vscode-versionlens
yarn && yarn run compile
```
Then copy the file `./out/extension-bundle.js` to your extension directory and replace the existing file. Mine was `~\.vscode\extensions\pflannery.vscode-versionlens-0.20.0\out`.

Enjoy!