### PR TITLE
Mitigation for invalid semver packages

### DIFF
--- a/src/common/versionUtils.js
+++ b/src/common/versionUtils.js
@@ -113,6 +113,17 @@ export function parseVersion(version) {
 
 /**
  * @export
+ * @param {Array<String>} versions 
+ * @param {String} requestedVersion 
+ * @returns {Boolean}
+ */
+export function validateVersions(versions, requestedVersion) {
+  const validList = [requestedVersion, ...versions].filter(version => semver.valid(version) !== null);
+  return validList.length === (versions.length + 1);
+}
+
+/**
+ * @export
  * @param {String} versionToCheck 
  * @returns {Boolean}
  */

--- a/src/providers/dotnet/dotnetPackageParser.js
+++ b/src/providers/dotnet/dotnetPackageParser.js
@@ -21,7 +21,7 @@ export function dotnetPackageParser(name, requestedVersion, appContrib) {
   return nugetGetPackageVersions(name)
     .then(versions => {
       
-      // validate semvar formats
+      // validate semver formats
       if (!validateVersions(versions, requestedVersion)) {
         throw TypeError("Invalid Version")
       }
@@ -87,7 +87,7 @@ export function dotnetPackageParser(name, requestedVersion, appContrib) {
           'nuget'
         );
       }
-      // show invalid version to user if invalid semvar format is used
+      // show invalid version to user if invalid semver format is used
       if (error.message.indexOf("Invalid Version") !== -1) {
         return PackageFactory.createInvalidVersion(
           name,


### PR DESCRIPTION
Fixes #119 
If packages don't follow semver, the extension bubbles out errors and fails to render any information. This fixes this issue by looking for errors that produce error with message containing 'Invalid Version' and displaying invalid version.