### PR TITLE
Return error package if it can't parse the package

### DIFF
--- a/src/commands/factory.js
+++ b/src/commands/factory.js
@@ -188,6 +188,13 @@ export function createPackageNotSupportedCommand(codeLens) {
   );
 }
 
+export function createPackageErrorCommand(codeLens) {
+  return createErrorCommand(
+    'An unexpected error occured',
+    codeLens
+  );
+}
+
 export function createVersionMatchNotFoundCommand(codeLens) {
   return createErrorCommand(
     `Match not found: ${codeLens.package.version}`,

--- a/src/common/packageCodeLens.js
+++ b/src/common/packageCodeLens.js
@@ -53,6 +53,10 @@ export class PackageCodeLens extends CodeLens {
     return this.package.meta.type === type;
   }
 
+  isErrored() {
+    return this.package.meta.tag.isErrored;
+  }
+
   matchesLatestVersion() {
     return this.package.meta.tag && this.package.meta.tag.isLatestVersion;
   }

--- a/src/common/packageCodeLens.js
+++ b/src/common/packageCodeLens.js
@@ -54,7 +54,8 @@ export class PackageCodeLens extends CodeLens {
   }
 
   isErrored() {
-    return this.package.meta.tag.isErrored;
+    return this.package.meta.tag
+      && this.package.meta.tag.isErrored;
   }
 
   matchesLatestVersion() {

--- a/src/common/packageGeneration.js
+++ b/src/common/packageGeneration.js
@@ -43,6 +43,18 @@ export function createInvalidVersion(name, version, type) {
   );
 }
 
+export function createPackageErrored(name, version, type) {
+  return createPackage(
+    name,
+    version, {
+      type,
+      tag: {
+        isErrored: true
+      }
+    }
+  );
+}
+
 export function createPackage(name, version, meta, customGenerateVersion) {
   return {
     name,

--- a/src/providers/dotnet/dotnetCodeLensProvider.js
+++ b/src/providers/dotnet/dotnetCodeLensProvider.js
@@ -47,6 +47,10 @@ export class DotNetCodeLensProvider extends AbstractCodeLensProvider {
   }
 
   evaluateCodeLens(codeLens) {
+    // check if error occured
+    if (codeLens.isErrored())
+      return CommandFactory.createPackageErrorCommand(codeLens);
+
     // check if this package was found
     if (codeLens.packageNotFound())
       return CommandFactory.createPackageNotFoundCommand(codeLens);

--- a/src/providers/dotnet/dotnetPackageParser.js
+++ b/src/providers/dotnet/dotnetPackageParser.js
@@ -81,7 +81,11 @@ export function dotnetPackageParser(name, requestedVersion, appContrib) {
       }
 
       console.error(error);
-      throw error;
+      return PackageFactory.createPackageErrored(
+        name,
+        requestedVersion,
+        'nuget'
+      )
     });
 
 }

--- a/test/unit/providers/dotnet/codeLensProvider/evaluateCodeLens.tests.js
+++ b/test/unit/providers/dotnet/codeLensProvider/evaluateCodeLens.tests.js
@@ -78,6 +78,14 @@ export default {
     assert.equal(result.command.title, '\u2191 3.2.1');
     assert.equal(result.command.command, 'versionlens.updateDependencyCommand');
     assert.equal(result.command.arguments[1], '3.2.1');
+  },
+
+  "returns errored": () => {
+    const codeLens = new PackageCodeLens(testContext.testRange, null, generatePackage('SomePackage', '1.2.3', { type: 'nuget', tag: { isErrored: true, version: '3.2.1' } }), null);
+    const result = testContext.testProvider.evaluateCodeLens(codeLens, null)
+    assert.equal(result.command.title, 'An unexpected error occured');
+    assert.equal(result.command.command, null);
+    assert.equal(result.command.arguments, null);
   }
 
 }


### PR DESCRIPTION
Closes: #119 

As per #120 changed the approach to not do anything special but just return an custom `PackageCodeLens` with `errored` tag that has `errorCommand`. This means that if package fails to parse it does not affect other packages by throwing exception up.

I've also noticed similar pattern of throwing exception in other places (e.g. mavenPackageParser) which could be changed to this to avoid fatal errors.