### PR TITLE
Make pub api url configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,16 @@
           ],
           "description": "Defines which properties in pubspec.yaml should be parsed by this extension"
         },
+        "versionlens.pub.apiSchema": {
+          "type": "string",
+          "default": "https",
+          "description": "Defines pub server api schema."
+        },
+        "versionlens.pub.apiHostPort": {
+          "type": "string",
+          "default": "pub.dev",
+          "description": "Defines pub server api host and port."
+        },
         "versionlens.dotnet.dependencyProperties": {
           "type": "array",
           "items": {

--- a/src/common/appContrib.js
+++ b/src/common/appContrib.js
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { npmDefaultDependencyProperties } from 'providers/npm/config';
-import { pubDefaultDependencyProperties } from 'providers/pub/config';
+import { pubDefaultDependencyProperties, pubDefaultApiSchema, pubDefaultApiHostPort } from 'providers/pub/config';
 import { dubDefaultDependencyProperties } from 'providers/dub/config';
 import {
   dotnetCSProjDefaultDependencyProperties,
@@ -50,6 +50,16 @@ export default new class AppContribution {
   get pubDependencyProperties() {
     const config = workspace.getConfiguration('versionlens');
     return config.get("pub.dependencyProperties", pubDefaultDependencyProperties);
+  }
+
+  get pubApiSchema() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("pub.apiSchema", pubDefaultApiSchema);
+  }
+
+  get pubApiHostPort() {
+    const config = workspace.getConfiguration('versionlens');
+    return config.get("pub.apiHostPort", pubDefaultApiHostPort);
   }
 
   get dotnetCSProjDependencyProperties() {

--- a/src/common/pubRequest.ts
+++ b/src/common/pubRequest.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ExpiryCacheMap } from "./expiryCacheMap";
+import appContrib from "../common/appContrib";
 
 class PubRequest {
   cache: ExpiryCacheMap;
@@ -10,7 +11,7 @@ class PubRequest {
   constructor() {
     this.cache = new ExpiryCacheMap();
     this.headers = {
-      referer: "https://pub.dev/packages"
+      referer: `${appContrib.pubApiSchema}://${appContrib.pubApiHostPort}/packages`
     };
   }
 
@@ -68,7 +69,7 @@ class PubRequest {
   }
 
   generatePubUrl(packageName: string): string {
-    return `https://pub.dev/api/documentation/${packageName}`;
+    return `${appContrib.pubApiSchema}://${appContrib.pubApiHostPort}/api/documentation/${packageName}`;
   }
 }
 

--- a/src/providers/pub/config.ts
+++ b/src/providers/pub/config.ts
@@ -2,3 +2,7 @@ export const pubDefaultDependencyProperties = [
   "dependencies",
   "dev_dependencies"
 ];
+
+export const pubDefaultApiSchema = "https";
+
+export const pubDefaultApiHostPort = "pub.dev";


### PR DESCRIPTION
pub.dev has limited accessiblity in some areas(e.g. China) .  Official flutter document suggests using mirror site http://pub.flutter-io.cn . 

This PR makes pub api url configurable, please let me know your concerns