### PR TITLE
[Dart] Fix dependencies declared without a version

### DIFF
--- a/src/providers/pub/pubPackageParser.ts
+++ b/src/providers/pub/pubPackageParser.ts
@@ -29,6 +29,10 @@ export function extractPackageLensDataFromNodes(topLevelNodes, filterPropertyNam
 function collectDependencyNodes(nodes, collector = []) {
   nodes.forEach(
     function (pair) {
+      if (!pair.value) {
+        // node may be in the form "no_version_dep:", which we ignore
+        return;
+      }
       if (typeof pair.value.value === 'string') {
         const packageLens = createPackageLensFromProperty(pair);
         collector.push(packageLens);

--- a/test/fixtures/pub/pubspec-with-deps.yaml
+++ b/test/fixtures/pub/pubspec-with-deps.yaml
@@ -13,12 +13,18 @@ environment:
   sdk: ">=2.0.0-dev.9.4.flutter-f9ebf21297 <3.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
+  
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   dep1: 0.1.2
   dep2: 0.10.1
   dep3: ^0.2.0
+  gitdep:
+    git: git://github.com/someuser/somerepo.git
   dep4: 0.6.0-beta+1
+  depnoversion: 
 
 dev_dependencies:
   dep5: 0.10.3+4

--- a/test/smoke/pub/pubspec.yaml
+++ b/test/smoke/pub/pubspec.yaml
@@ -21,7 +21,12 @@ dependencies:
   cupertino_icons: 0.1.2
   flutter_bloc: 0.10.1
   equatable: ^0.2.0
+  sqflite:
+    git: 
+      url: https://github.com/tekartik/sqflite
+      path: sqflite
   cached_network_image: 0.6.0-beta+1
+  http:
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/providers/pub/pubCodeLensProvider/provideCodeLenses.tests.js
+++ b/test/unit/providers/pub/pubCodeLensProvider/provideCodeLenses.tests.js
@@ -117,7 +117,7 @@ export default {
         assert.equal(
           collection.length,
           5,
-          "codeLens should be an array containing 7 items."
+          "codeLens should be an array containing 5 items."
         );
 
         collection.forEach((entry, index) => {


### PR DESCRIPTION
In the `pubspec.yaml` file it is valid to declare a dependency just by its name. Without the fix, if such dependency is encountered all version lens would fail.

I've updated the test files with such use case.