### PR TITLE
dotnet: Filter to use only enabled sources

### DIFF
--- a/src/infrastructure/providers/dotnet/clients/dotnetClient.ts
+++ b/src/infrastructure/providers/dotnet/clients/dotnetClient.ts
@@ -40,7 +40,7 @@ export class DotNetClient extends ProcessClientRequest {
       // pop any blank entries
       if (lines[lines.length - 1] === '') lines.pop();
 
-      return parseSourcesArray(lines);
+      return parseSourcesArray(lines).filter(s => s.enabled);
     }).then(sources => {
       // combine the sources where feed take precedent
       const feedSources = convertFeedsToSources(this.config.nuget.sources);

--- a/src/infrastructure/providers/dotnet/dotnetProvider.ts
+++ b/src/infrastructure/providers/dotnet/dotnetProvider.ts
@@ -65,8 +65,13 @@ export class DotNetVersionLensProvider
     // get each service index source from the dotnet cli
     const sources = await this.dotnetClient.fetchSources(packagePath)
 
+    // enabled sources only
+    const enabledSources = sources.filter(
+      s => s.enabled
+    );
+
     // remote sources only
-    const remoteSources = sources.filter(
+    const remoteSources = enabledSources.filter(
       s => s.protocol === RegistryProtocols.https ||
         s.protocol === RegistryProtocols.http
     );

--- a/src/infrastructure/providers/dotnet/dotnetProvider.ts
+++ b/src/infrastructure/providers/dotnet/dotnetProvider.ts
@@ -65,13 +65,8 @@ export class DotNetVersionLensProvider
     // get each service index source from the dotnet cli
     const sources = await this.dotnetClient.fetchSources(packagePath)
 
-    // enabled sources only
-    const enabledSources = sources.filter(
-      s => s.enabled
-    );
-
     // remote sources only
-    const remoteSources = enabledSources.filter(
+    const remoteSources = sources.filter(
       s => s.protocol === RegistryProtocols.https ||
         s.protocol === RegistryProtocols.http
     );

--- a/test/unit/infrastructure/providers/dotnet/clients/fixtures/dotnetSources.ts
+++ b/test/unit/infrastructure/providers/dotnet/clients/fixtures/dotnetSources.ts
@@ -4,7 +4,10 @@ export default {
 E http://non-ssl/v3/index.json
 EM C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\`,
 
-  disabledSources: `D https://api.nuget.org/v3/index.json`,
+  disabledSource: `D https://api.nuget.org/v3/index.json`,
+
+  enabledAndDisabledSources: `D http://non-ssl/v3/index.json
+E https://api.nuget.org/v3/index.json`,
 
   invalidSources: 'error: invalid value'
 


### PR DESCRIPTION
So while it did parse whether the source was disabled (starting with D) it did not do anything about it, so it would still try to use sources that are disabled. This just filters them out in the provider. Unless that was intended behavior.