### PR TITLE
adds vsix package to artifact with github workflow

### DIFF
--- a/.github/workflows/vscode-tests.yml
+++ b/.github/workflows/vscode-tests.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Visual Studio Code Tests
 
 on:
@@ -11,7 +8,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -20,24 +17,69 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    # checkout master
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
 
-    # additional packages for linux
-    - name: install packages (linux)
-      run: sudo apt-get install xvfb
-      if: matrix.os == 'ubuntu-latest'
-
+    # install
     - name: npm clean install
       run: npm ci
 
+    # test on windows and mac
     - name: vscode tests (windows or mac)
       run: npm test
       if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
 
+    # test on linux
+    - name: install packages (linux)
+      run: sudo apt-get install xvfb
+      if: matrix.os == 'ubuntu-latest'
+
     - name: vscode tests (linux)
       run: xvfb-run --auto-servernum npm test
       if: matrix.os == 'ubuntu-latest'
+
+  package:
+    needs: test
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo "::set-env name=PKG_VERSION::$( date +%Y.%-m.%-d-build.%-H%-M )"
+      - run: echo "::set-env name=PKG_NAME::versionlens-${{ env.PKG_VERSION }}.vsix"
+
+      # checkout master
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # install
+      - name: npm clean install
+        run: |
+          npm ci
+          npm i vsce -g
+
+      # replace package.json version with x.x.x.build
+      - name: replace package.json
+        run: |
+          node -p "JSON.stringify({...require('./package.json'), 'version': '${{ env.PKG_VERSION }}'}, null, '\t')" > new-package.json
+          mv new-package.json package.json
+
+      # package
+      - name: package extension
+        run: vsce package --out ${{ env.PKG_NAME }}
+
+      # save to build artifacts
+      - name: Create package artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PKG_VERSION }}
+          path: ${{ env.PKG_NAME }}


### PR DESCRIPTION
This PR packages vsix files and adds them to the ci artifacts.

It generates the extension vsix file using a build version `yyyy.m.d-build.hhss` format. 

These files aren't meant for release or general consumtion (although available to all). 
They are to save dev time in previewing builds in vscode. It also gives early [vscode-vsce](https://github.com/microsoft/vscode-vsce) fail warnings (e.g. things like unknown links to svg's make vscode-vsce fail)

![image](https://user-images.githubusercontent.com/1727302/82742234-5c9f1f80-9d53-11ea-851d-320950e6b614.png)

A seperate PR will follow to generate vsix files for actual releases and prereleases in the typical version format 1.x.x (for general consumption). Will probably be scheduled as nightly build of any changes during the day.

**note:** actions/upload-artifact@v2 always zips artifacts. A no zip option is hopefully coming in a future version. See actions/upload-artifact/issues/39.

