### PR TITLE
ignore nuget source failures

### DIFF
--- a/src/infrastructure.providers/dotnet/src/clients/nugetResourceClient.ts
+++ b/src/infrastructure.providers/dotnet/src/clients/nugetResourceClient.ts
@@ -47,12 +47,15 @@ export class NuGetResourceClient {
       })
       .catch((error: HttpClientResponse) => {
 
+        
+        const msg = error.data === undefined ? (error as any).message : error.data;
         this.logger.error(
-          "Could not resolve nuget service index. %s",
-          error.data
+          "Could not resolve nuget service index (%s). %s",
+          source.url,
+          msg
         )
 
-        return Promise.reject(error)
+        return "";
       });
 
   }

--- a/src/infrastructure.providers/dotnet/src/clients/nugetResourceClient.ts
+++ b/src/infrastructure.providers/dotnet/src/clients/nugetResourceClient.ts
@@ -47,12 +47,9 @@ export class NuGetResourceClient {
       })
       .catch((error: HttpClientResponse) => {
 
-        
-        const msg = error.data === undefined ? (error as any).message : error.data;
         this.logger.error(
-          "Could not resolve nuget service index (%s). %s",
-          source.url,
-          msg
+          "Could not resolve nuget service index. %O",
+          error
         )
 
         return "";

--- a/src/infrastructure.providers/dotnet/src/dotnetSuggestionProvider.ts
+++ b/src/infrastructure.providers/dotnet/src/dotnetSuggestionProvider.ts
@@ -79,13 +79,15 @@ export class DotNetSuggestionProvider implements ISuggestionProvider {
       }
     );
 
-    var autoCompleteUrls = await Promise.all(promised);
-    if (autoCompleteUrls.length === 0) return null;
+    const serviceUrls = (await Promise.all(promised))
+      .filter(url => url.length > 0);
 
-    // filter out unresolvable urls
-    autoCompleteUrls = autoCompleteUrls.filter((url) => url.length > 0);
+    if (serviceUrls.length === 0) {
+      this.logger.error("Could not resolve any nuget service urls")
+      return null;
+    }
 
-    const clientData: NuGetClientData = { serviceUrls: autoCompleteUrls }
+    const clientData: NuGetClientData = { serviceUrls: serviceUrls }
 
     return RequestFactory.executeDependencyRequests(
       packagePath,

--- a/src/infrastructure.providers/dotnet/src/dotnetSuggestionProvider.ts
+++ b/src/infrastructure.providers/dotnet/src/dotnetSuggestionProvider.ts
@@ -79,8 +79,11 @@ export class DotNetSuggestionProvider implements ISuggestionProvider {
       }
     );
 
-    const autoCompleteUrls = await Promise.all(promised);
+    var autoCompleteUrls = await Promise.all(promised);
     if (autoCompleteUrls.length === 0) return null;
+
+    // filter out unresolvable urls
+    autoCompleteUrls = autoCompleteUrls.filter((url) => url.length > 0);
 
     const clientData: NuGetClientData = { serviceUrls: autoCompleteUrls }
 

--- a/src/infrastructure.providers/dotnet/test/clients/nugetResourceClient.tests.ts
+++ b/src/infrastructure.providers/dotnet/test/clients/nugetResourceClient.tests.ts
@@ -61,7 +61,7 @@ export const NuGetResourceClientTests = {
         });
     },
 
-    "throws an error when no resource or feeds can be obtained": async () => {
+    "returns empty when the resource cannot be obtained": async () => {
 
       const testSource = {
         enabled: true,
@@ -70,15 +70,17 @@ export const NuGetResourceClientTests = {
         protocol: UrlHelpers.RegistryProtocols.https
       };
 
-      const expectedResponse = {
+      const errorResponse = {
         source: 'remote',
         status: 404,
         data: 'an error occurred',
         rejected: true
       };
 
+      const expectedUrl = "";
+
       when(jsonClientMock.request(anything(), anything(), anything(), anything()))
-        .thenReject(expectedResponse)
+        .thenReject(errorResponse)
 
       const cut = new NuGetResourceClient(
         instance(jsonClientMock),
@@ -86,9 +88,13 @@ export const NuGetResourceClientTests = {
       )
 
       await cut.fetchResource(testSource)
+        .then(actualUrl => {
+          assert.equal(actualUrl, expectedUrl)
+        })
         .catch(err => {
-          assert.deepEqual(err, expectedResponse)
+          assert.fail();
         });
+
     },
 
   }

--- a/test/smoke/dotnet/NuGet.config
+++ b/test/smoke/dotnet/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <add key="Unreachable" value="http://unreachablenugetindex.local" />
+ </packageSources>
+</configuration>


### PR DESCRIPTION
Attempt at addressing #262 

Wasn't sure how best to test this, included a `NuGet.config` with an unreachable source in the smoke tests. I'd also like to be able to add a test for when the returned content is not properly formatted json. I'm honestly unsure how best to handle add the proper testing.

